### PR TITLE
chore: fine-tune the check tasks for the two publishing workflows.

### DIFF
--- a/.github/workflows/publish-gradle-plugin.yml
+++ b/.github/workflows/publish-gradle-plugin.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
 
-      - name: Execute check
-        run: './gradlew check -s'
+      - name: Check non-IDE plugin
+        run: './gradlew check -x :check -s'
 
       - name: Publish artifacts
         run: './gradlew publishAllPublicationsToMavenCentralRepository -s --no-configuration-cache'

--- a/.github/workflows/publish-ide-metrics-plugin.yml
+++ b/.github/workflows/publish-ide-metrics-plugin.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
 
-      - name: Execute check
-        run: './gradlew check -s'
+      - name: Check IDE plugin
+        run: './gradlew :check -s'
 
       - name: Publish
         env:


### PR DESCRIPTION
```Caused by: java.io.IOException: No space left on device``` on my gradle publishing workflow

I imagine this will hit the IDE publishing workflow as well. Hmmm.