### PR TITLE
fix: Prevent exceptions when cancelling sync

### DIFF
--- a/src/main/kotlin/xyz/block/idea/telemetry/events/SyncResult.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/events/SyncResult.kt
@@ -55,7 +55,7 @@ internal sealed class SyncResult(
     override val gradleVersion: GradleVersion?,
     override val startTimestamp: Long,
     override val finishTimestamp: Long,
-    val phase: SyncPhase,
+    val phase: SyncPhase?,
     val exception: Throwable,
   ) : SyncResult(buildTraceId, gradleVersion, startTimestamp, finishTimestamp)
 
@@ -64,6 +64,6 @@ internal sealed class SyncResult(
     override val gradleVersion: GradleVersion?,
     override val startTimestamp: Long,
     override val finishTimestamp: Long,
-    val phase: SyncPhase,
+    val phase: SyncPhase?,
   ) : SyncResult(buildTraceId, gradleVersion, startTimestamp, finishTimestamp)
 }

--- a/src/main/kotlin/xyz/block/idea/telemetry/services/SyncState.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/services/SyncState.kt
@@ -121,7 +121,7 @@ internal class SyncState(private val project: Project) {
       gradleVersion,
       startTimestamp,
       finishTimestamp,
-      phases.pop()
+      phases.pollFirst()
     ))
   }
 
@@ -133,7 +133,7 @@ internal class SyncState(private val project: Project) {
       gradleVersion,
       startTimestamp,
       finishTimestamp,
-      phases.pop(),
+      phases.pollFirst(),
       error
     ))
   }

--- a/src/main/kotlin/xyz/block/idea/telemetry/services/SyncState.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/services/SyncState.kt
@@ -20,6 +20,7 @@ internal class SyncState(private val project: Project) {
     val Project.syncState: SyncState get() = get(this)
   }
 
+  private val lock = Any()
   private var startTimestamp: Long = -1
   private var hasIncludedBuilds: Boolean = false
   private var finishConfigureIncludedBuildsTimestamp: Long = -1
@@ -61,80 +62,100 @@ internal class SyncState(private val project: Project) {
   }
 
   fun syncStarted() {
-    thisLogger().info("syncStarted")
-    reset()
-    phases.pop()
-    startTimestamp = now()
+    synchronized(lock) {
+      thisLogger().info("syncStarted")
+      reset()
+      phases.pollFirst()
+      startTimestamp = now()
+    }
   }
 
   fun hasIncludedBuilds() {
-    thisLogger().info("hasIncludedBuilds")
-    hasIncludedBuilds = true
+    synchronized(lock) {
+      thisLogger().info("hasIncludedBuilds")
+      hasIncludedBuilds = true
+    }
   }
 
   fun syncConfigureIncludedBuildsFinished() {
-    thisLogger().info("syncConfigureIncludedBuildsFinished")
-    phases.pop()
-    finishConfigureIncludedBuildsTimestamp = now()
+    synchronized(lock) {
+      thisLogger().info("syncConfigureIncludedBuildsFinished")
+      phases.pollFirst()
+      finishConfigureIncludedBuildsTimestamp = now()
+    }
   }
 
   fun syncConfigureRootBuildFinished(gradleVersion: GradleVersion?) {
-    thisLogger().info("syncConfigureRootBuildFinished ($gradleVersion)")
-    if (!hasIncludedBuilds) {
-      phases.pop()
+    synchronized(lock) {
+      thisLogger().info("syncConfigureRootBuildFinished ($gradleVersion)")
+      if (!hasIncludedBuilds) {
+        phases.pollFirst()
+      }
+      phases.pollFirst()
+      this.gradleVersion = gradleVersion
+      finishConfigureRootBuildTimestamp = now()
     }
-    phases.pop()
-    this.gradleVersion = gradleVersion
-    finishConfigureRootBuildTimestamp = now()
   }
 
   fun syncGradleFinished(projectCount: Int) {
-    thisLogger().info("syncGradleFinished")
-    phases.pop()
-    gradleFinishTimestamp = now()
-    gradleProjectCount = projectCount
+    synchronized(lock) {
+      thisLogger().info("syncGradleFinished")
+      phases.pollFirst()
+      gradleFinishTimestamp = now()
+      gradleProjectCount = projectCount
+    }
   }
 
   fun syncFinished() {
-    thisLogger().info("syncFinished")
-    finishTimestamp = now()
-    logEvent(
-      SyncResult.SyncSucceeded(
-        project.buildTraceId,
-        gradleVersion,
-        startTimestamp,
-        finishTimestamp,
-        gradleProjectCount,
-        hasIncludedBuilds,
-        finishConfigureIncludedBuildsTimestamp,
-        finishConfigureRootBuildTimestamp,
-        gradleFinishTimestamp
+    synchronized(lock) {
+      thisLogger().info("syncFinished")
+      finishTimestamp = now()
+      logEvent(
+        SyncResult.SyncSucceeded(
+          project.buildTraceId,
+          gradleVersion,
+          startTimestamp,
+          finishTimestamp,
+          gradleProjectCount,
+          hasIncludedBuilds,
+          finishConfigureIncludedBuildsTimestamp,
+          finishConfigureRootBuildTimestamp,
+          gradleFinishTimestamp
+        )
       )
-    )
+    }
   }
 
   fun syncCanceled() {
-    thisLogger().info("syncCanceled")
-    finishTimestamp = now()
-    logEvent(SyncResult.SyncCancelled(
-      project.buildTraceId,
-      gradleVersion,
-      startTimestamp,
-      finishTimestamp,
-      phases.pollFirst()
-    ))
+    synchronized(lock) {
+      thisLogger().info("syncCanceled")
+      finishTimestamp = now()
+      logEvent(
+        SyncResult.SyncCancelled(
+          project.buildTraceId,
+          gradleVersion,
+          startTimestamp,
+          finishTimestamp,
+          phases.pollFirst()
+        )
+      )
+    }
   }
 
   fun syncError(error: Throwable) {
-    thisLogger().error("syncError", error)
-    finishTimestamp = now()
-    logEvent(SyncResult.SyncFailed(
-      project.buildTraceId,
-      gradleVersion,
-      startTimestamp,
-      finishTimestamp,
-      phases.pollFirst(),
-      error
-    ))
+    synchronized(lock) {
+      thisLogger().error("syncError", error)
+      finishTimestamp = now()
+      logEvent(
+        SyncResult.SyncFailed(
+          project.buildTraceId,
+          gradleVersion,
+          startTimestamp,
+          finishTimestamp,
+          phases.pollFirst(),
+          error
+        )
+      )
+    }
   }
 }


### PR DESCRIPTION
Sometimes if sync fails or is cancelled at the right time, the current phase stack is empty

```
com.intellij.diagnostic.PluginException: null [Plugin: xyz.block.idea.telemetry]
	at com.intellij.serviceContainer.ComponentManagerImpl.createError(ComponentManagerImpl.kt:955)
	at com.intellij.openapi.extensions.ExtensionPointName.forEachExtensionSafe(ExtensionPointName.kt:385)
	at com.intellij.openapi.externalSystem.service.remote.ExternalSystemProgressNotificationManagerImpl.forEachListener$lambda$13(ExternalSystemProgressNotificationManagerImpl.kt:97)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeNonCancelableSection$3(CoreProgressManager.java:290)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:756)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:712)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$computeInNonCancelableSection$4(CoreProgressManager.java:298)
	at com.intellij.openapi.progress.Cancellation.computeInNonCancelableSection(Cancellation.java:139)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeInNonCancelableSection(CoreProgressManager.java:298)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeNonCancelableSection(CoreProgressManager.java:289)
	at com.intellij.openapi.externalSystem.service.remote.ExternalSystemProgressNotificationManagerImpl.forEachListener(ExternalSystemProgressNotificationManagerImpl.kt:94)
	at com.intellij.openapi.externalSystem.service.remote.ExternalSystemProgressNotificationManagerImpl.onCancel(ExternalSystemProgressNotificationManagerImpl.kt:78)
	at com.intellij.openapi.externalSystem.service.internal.AbstractExternalSystemTask.withExecutionProgressManager(AbstractExternalSystemTask.java:226)
	at com.intellij.openapi.externalSystem.service.internal.AbstractExternalSystemTask.lambda$execute$2(AbstractExternalSystemTask.java:135)
	at com.intellij.openapi.externalSystem.service.internal.AbstractExternalSystemTask.withProcessingManager(AbstractExternalSystemTask.java:208)
	at com.intellij.openapi.externalSystem.service.internal.AbstractExternalSystemTask.execute(AbstractExternalSystemTask.java:134)
	at com.intellij.openapi.externalSystem.service.internal.AbstractExternalSystemTask.execute(AbstractExternalSystemTask.java:117)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil.lambda$executeSync$1(ExternalSystemUtil.java:456)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil.incompleteDependenciesState(ExternalSystemUtil.java:475)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil.executeSync(ExternalSystemUtil.java:453)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$2.lambda$execute$0(ExternalSystemUtil.java:319)
	at com.intellij.openapi.externalSystem.util.ExternalSystemTelemetryUtil.lambda$runWithSpan$0(ExternalSystemTelemetryUtil.java:26)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.use(trace.kt:29)
	at com.intellij.openapi.externalSystem.util.ExternalSystemTelemetryUtil.runWithSpan(ExternalSystemTelemetryUtil.java:25)
	at com.intellij.openapi.externalSystem.util.ExternalSystemUtil$2.execute(ExternalSystemUtil.java:318)
	at com.intellij.openapi.externalSystem.util.ExternalSystemTaskUnderProgress$2.run(ExternalSystemTaskUnderProgress.java:55)
	at com.intellij.openapi.progress.impl.CoreProgressManager.startTask(CoreProgressManager.java:498)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.startTask(ProgressManagerImpl.java:119)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsynchronously$7(CoreProgressManager.java:549)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:252)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:98)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:229)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.use(trace.kt:44)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:228)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:681)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:756)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:712)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:680)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:78)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:209)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:98)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$5(ProgressRunner.java:252)
	at com.intellij.openapi.progress.impl.ProgressRunner$ProgressRunnable.run(ProgressRunner.java:515)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$launchTask$18(ProgressRunner.java:480)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:167)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:167)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:173)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:167)
	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$launchTask$19(ProgressRunner.java:476)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Unknown Source)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Unknown Source)
	at java.base/java.security.AccessController.doPrivileged(Unknown Source)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.util.NoSuchElementException
	at java.base/java.util.LinkedList.removeFirst(Unknown Source)
	at java.base/java.util.LinkedList.pop(Unknown Source)
	at xyz.block.idea.telemetry.services.SyncState.syncCanceled(SyncState.kt:124)
	at xyz.block.idea.telemetry.listeners.sync.GradleResolveProjectTaskListener.onCancel(GradleResolveProjectTaskListener.kt:46)
	at com.intellij.openapi.externalSystem.service.remote.ExternalSystemProgressNotificationManagerImpl.onCancel$lambda$10(ExternalSystemProgressNotificationManagerImpl.kt:78)
	at com.intellij.openapi.externalSystem.service.remote.ExternalSystemProgressNotificationManagerImpl$forEachListener$1$1$1.invoke(ExternalSystemProgressNotificationManagerImpl.kt:97)
	at com.intellij.openapi.externalSystem.service.remote.ExternalSystemProgressNotificationManagerImpl$forEachListener$1$1$1.invoke(ExternalSystemProgressNotificationManagerImpl.kt:97)
	at com.intellij.openapi.externalSystem.service.remote.ExternalSystemProgressNotificationManagerImpl.forEachListener$lambda$13$lambda$12$lambda$11(ExternalSystemProgressNotificationManagerImpl.kt:97)
	at com.intellij.openapi.extensions.ExtensionPointName.forEachExtensionSafe(ExtensionPointName.kt:61)
	... 54 more
```