### PR TITLE
Upgrade untilBuild to 261 and fix automated version upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ version = providers.environmentVariable("IJ_PLUGIN_VERSION").getOrElse("unknown"
 val pluginName = providers.gradleProperty("pluginName").get()
 val sinceBuildMajorVersion = "252" // corresponds to 2025.2.x versions
 val sinceIdeVersionForVerification = "252.23892.409" // corresponds to the 2025.2 version
-val untilIdeVersion = providers.gradleProperty("IIC.release.version").get()
+val untilIdeVersion = providers.gradleProperty("IIU.release.version").get()
 val untilBuildMajorVersion = untilIdeVersion.substringBefore('.')
 
 val javaVersion = JavaLanguageVersion.of(libs.versions.java.get()).toString()

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ pluginGroup=xyz.block.idea.telemetry
 pluginName=build-sync-metrics
 pluginRepositoryUrl=https://github.com/block/ide-metrics-plugin
 # The latest supported versions. Note that these are updated automatically
-IIC.release.version=253.28294.334
+IIU.release.version=261.22158.277
 
 # Stop failures like this:
 #   > Task :initializeIntellijPlatformPlugin


### PR DESCRIPTION
## Summary
- Bumps `IIC.release.version` from `253.28294.334` to `261.22158.277` to fix plugin incompatibility with IDE build 261.x (2026.1)
- Renames property key from `IIC.release.version` to `IIU.release.version` in `gradle.properties` and `build.gradle.kts`, aligning with the upgrade script so the daily automated version bump workflow works again
- IIC (Community) was discontinued by JetBrains; IIU (Ultimate) is the correct target

## Test plan
- [x] `./gradlew buildPlugin` passes
- [ ] Verify plugin installs on IDE 261.x
- [ ] Run `./gradlew verifyPlugin` for full binary compatibility check
- [ ] Trigger the `Idea major version upgrade` workflow to confirm automation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)