### PR TITLE
Remove untilBuild cap so plugin works on all future IDE versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,6 @@ val pluginName = providers.gradleProperty("pluginName").get()
 val sinceBuildMajorVersion = "252" // corresponds to 2025.2.x versions
 val sinceIdeVersionForVerification = "252.23892.409" // corresponds to the 2025.2 version
 val untilIdeVersion = providers.gradleProperty("IIU.release.version").get()
-val untilBuildMajorVersion = untilIdeVersion.substringBefore('.')
 
 val javaVersion = JavaLanguageVersion.of(libs.versions.java.get()).toString()
 
@@ -73,7 +72,7 @@ intellijPlatform {
     }
     ideaVersion {
       sinceBuild = sinceBuildMajorVersion
-      untilBuild = "$untilBuildMajorVersion.*"
+      // No untilBuild — plugin is compatible with all future IDE versions
     }
   }
   pluginVerification {


### PR DESCRIPTION
Removes the `untilBuild` constraint from `pluginConfiguration` so the plugin installs on any future IDE version without needing a version bump each release. The `IIU.release.version` property is still used for `pluginVerification` to ensure binary compatibility against a known range. This matches how artifact-swap handles it.