### PR TITLE
Add Bazel sync metrics via the JetBrains Bazel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ https://plugins.jetbrains.com/plugin/28394-build-sync-metrics
 
 ## Usage
 
-This plugin supports two telemetry backends. The plugin automatically detects which backend to use based on the URL you configure.
+The plugin records IDE sync metrics for Gradle projects, and for Bazel projects when the **Bazel by JetBrains** plugin (`org.jetbrains.bazel`) is installed. Bazel syncs report duration, module count, and outcome (succeeded/partially_succeeded/failed/cancelled, observed via the IDE's Sync view since the Bazel plugin's public API does not expose success/failure; falls back to "finished" if the outcome cannot be determined). Per-phase timings are not available for Bazel.
+
+This plugin supports two telemetry backends. The plugin automatically detects which backend to use based on the URL you configure. The endpoint is read from `gradle.properties` at the project root. A repo that doesn't use Gradle (e.g. Bazel) can instead put the same properties in a file named `ide-metrics-plugin.config-file` at the project root (the same file `gradle.properties` can delegate to, see [Advanced: Delegate Config File](#advanced-delegate-config-file)).
 
 ### Option 1: Eventstream
 
@@ -44,7 +46,8 @@ Use these exact placeholder codes when generating your prefilled link:
 
 | Field | Placeholder Code | Description |
 |-------|------------------|-------------|
-| Sync Type | `SYNC_TYPE` | succeeded/failed/cancelled |
+| Sync Type | `SYNC_TYPE` | succeeded/failed/cancelled for Gradle; succeeded/partially_succeeded/failed/cancelled (or finished) for Bazel |
+| Build Tool | `BUILD_TOOL` | gradle or bazel |
 | Sync Time | `SYNC_TIME` | Total duration in milliseconds |
 | Configure Included Builds Duration | `CONFIGURE_INCLUDED_BUILDS_DURATION` | Phase duration in ms |
 | Configure Root Project Duration | `CONFIGURE_ROOT_PROJECT_DURATION` | Phase duration in ms |
@@ -95,3 +98,5 @@ and
 # preferred-config-file.properties
 ide-metrics-plugin.event-stream-endpoint=<endpoint>
 ```
+
+If there is no `gradle.properties` (e.g. a Bazel repo), the plugin reads a file named `ide-metrics-plugin.config-file` at the project root directly.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
 //    androidStudio("2024.3.1.13")
 
     bundledPlugin("com.intellij.gradle")
+    // Compile against the JetBrains Bazel plugin to observe Bazel sync events.
+    // This is an optional dependency at runtime (see plugin.xml).
+    plugin("org.jetbrains.bazel", "2025.2.12")
 
     pluginVerifier()
     zipSigner()
@@ -113,6 +116,15 @@ intellijPlatformTesting {
 }
 
 tasks {
+  // Jars copied into the sandbox from the Gradle transform cache (e.g. the Bazel plugin) are
+  // read-only, which makes subsequent sandbox syncs fail with "Permission denied" when they
+  // try to overwrite them. Make the previous sandbox contents writable before syncing.
+  withType<org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask>().configureEach {
+    doFirst {
+      destinationDir.walkBottomUp().forEach { it.setWritable(true) }
+    }
+  }
+
   buildPlugin {
     archiveBaseName = pluginName
   }

--- a/src/main/kotlin/xyz/block/idea/telemetry/events/SyncEvent.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/events/SyncEvent.kt
@@ -8,6 +8,9 @@ data class SyncEvent(
   /** The type of sync event that was detected. */
   @Json(name = "telemetry_android_sync_type") val syncType: String,
 
+  /** The build tool that performed the sync, e.g. "gradle" or "bazel" */
+  @Json(name = "build_tool") val buildTool: String,
+
   /** Amount of time the sync event took, in milliseconds */
   @Json(name = "telemetry_android_sync_time") val syncTime: Long,
 

--- a/src/main/kotlin/xyz/block/idea/telemetry/events/SyncResult.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/events/SyncResult.kt
@@ -15,6 +15,12 @@ internal sealed class SyncResult(
     is SyncSucceeded -> "succeeded"
     is SyncCancelled -> "cancelled"
     is SyncFailed -> "failed"
+    is BazelSync -> outcome
+  }
+
+  val buildTool: String get() = when (this) {
+    is BazelSync -> "bazel"
+    else -> "gradle"
   }
 
   data class SyncSucceeded(
@@ -66,4 +72,18 @@ internal sealed class SyncResult(
     override val finishTimestamp: Long,
     val phase: SyncPhase?,
   ) : SyncResult(buildTraceId, gradleVersion, startTimestamp, finishTimestamp)
+
+  /**
+   * A Bazel sync, from the JetBrains Bazel plugin (org.jetbrains.bazel).
+   */
+  data class BazelSync(
+    override val startTimestamp: Long,
+    override val finishTimestamp: Long,
+    /**
+     * "succeeded", "partially_succeeded", "failed", or "cancelled". Falls back to "finished"
+     * when the outcome could not be observed (see BazelSyncOutcomeTracker).
+     */
+    val outcome: String,
+    val moduleCount: Int = -1,
+  ) : SyncResult(null, null, startTimestamp, finishTimestamp)
 }

--- a/src/main/kotlin/xyz/block/idea/telemetry/listeners/sync/BazelSyncListener.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/listeners/sync/BazelSyncListener.kt
@@ -1,0 +1,62 @@
+package xyz.block.idea.telemetry.listeners.sync
+
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import org.jetbrains.bazel.sync.status.SyncStatusListener
+import xyz.block.idea.telemetry.events.SyncResult
+import xyz.block.idea.telemetry.services.Analytics.Companion.analyticsService
+import xyz.block.idea.telemetry.util.now
+
+/**
+ * Listens for sync events from the JetBrains Bazel plugin (org.jetbrains.bazel).
+ *
+ * Registered in bazel-metrics.xml, which is only loaded when the Bazel plugin is installed.
+ *
+ * The Bazel plugin's public [SyncStatusListener] API only reports start/finish/cancelled, so
+ * the exact outcome (succeeded/failed) is taken from [BazelSyncOutcomeTracker], which observes
+ * the Sync tool window events; if unavailable, the outcome falls back to "finished". There are
+ * no per-phase durations. Note that a "phased" Bazel sync fires two start/finish pairs (one
+ * per phase), which results in two events.
+ */
+internal class BazelSyncListener(private val project: Project) : SyncStatusListener {
+
+  @Volatile
+  private var startTimestamp: Long = -1
+
+  override fun syncStarted() {
+    thisLogger().info("Bazel syncStarted")
+    startTimestamp = now()
+    // Instantiating the tracker here (before the Bazel plugin opens its sync console) ensures
+    // it observes the sync's build events from the start.
+    project.getService(BazelSyncOutcomeTracker::class.java).syncWindowStarted()
+  }
+
+  override fun syncFinished(canceled: Boolean) {
+    val start = startTimestamp
+    startTimestamp = -1
+    if (start == -1L) return
+
+    val finish = now()
+    val observedOutcome = project.getService(BazelSyncOutcomeTracker::class.java).consumeOutcome()
+    val result = if (canceled) {
+      SyncResult.BazelSync(start, finish, outcome = "cancelled")
+    } else {
+      val moduleCount = ReadAction.compute<Int, RuntimeException> {
+        ModuleManager.getInstance(project).modules.size
+      }
+      SyncResult.BazelSync(start, finish, outcome = observedOutcome ?: "finished", moduleCount = moduleCount)
+    }
+
+    thisLogger().info("Bazel sync ${result.resultName} in ${result.totalDuration}ms")
+    project.analyticsService.recordSyncEvent(result)
+  }
+
+  // Explicit no-op overrides (instead of relying on the interface's default implementations)
+  // so this class has no binary dependency on DefaultImpls, which may not exist in other
+  // versions of the Bazel plugin.
+  override fun allTasksCancelled() = Unit
+
+  override fun targetUtilAvailable() = Unit
+}

--- a/src/main/kotlin/xyz/block/idea/telemetry/listeners/sync/BazelSyncOutcomeTracker.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/listeners/sync/BazelSyncOutcomeTracker.kt
@@ -1,0 +1,99 @@
+package xyz.block.idea.telemetry.listeners.sync
+
+import com.intellij.build.BuildProgressListener
+import com.intellij.build.SyncViewManager
+import com.intellij.build.events.BuildEvent
+import com.intellij.build.events.FailureResult
+import com.intellij.build.events.FinishBuildEvent
+import com.intellij.build.events.SkippedResult
+import com.intellij.build.events.SuccessResult
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+import org.jetbrains.bsp.protocol.TaskId
+
+/**
+ * Observes the build events the Bazel plugin publishes to the Sync view to determine the
+ * outcome of a Bazel sync.
+ *
+ * The Bazel plugin's public [org.jetbrains.bazel.sync.status.SyncStatusListener] API only
+ * reports finished/cancelled, but the plugin finishes its sync build in the Sync view with a
+ * typed result (failure/success/skipped).
+ *
+ * How the plugin reports its sync build is an implementation detail, not a stable API, so
+ * [consumeOutcome] may return null if the plugin's behavior changes; callers should fall back
+ * to a generic outcome.
+ */
+@Service(Service.Level.PROJECT)
+internal class BazelSyncOutcomeTracker(project: Project) : BuildProgressListener, Disposable {
+
+  private val lock = Any()
+  private var lastOutcome: String? = null
+
+  init {
+    project.getService(SyncViewManager::class.java).addListener(this, this)
+  }
+
+  /** Called when a Bazel sync starts. Clears any outcome left over from a previous sync. */
+  fun syncWindowStarted() {
+    synchronized(lock) {
+      lastOutcome = null
+    }
+  }
+
+  /**
+   * Returns the outcome ("succeeded", "partially_succeeded", "failed", or "cancelled") of the
+   * Bazel sync build observed since [syncWindowStarted], or null if none was observed.
+   */
+  fun consumeOutcome(): String? = synchronized(lock) {
+    val outcome = lastOutcome
+    lastOutcome = null
+    outcome
+  }
+
+  override fun onEvent(buildId: Any, event: BuildEvent) {
+    if (event !is FinishBuildEvent || !isBazelSyncBuild(buildId)) return
+    val outcome = when (val result = event.result) {
+      is FailureResult -> "failed"
+      is SkippedResult -> "cancelled"
+      // The Bazel plugin reports partial success (some targets failed to import) as a
+      // success result with isUpToDate = true; a plain success has isUpToDate = false.
+      is SuccessResult -> if (result.isUpToDate) "partially_succeeded" else "succeeded"
+      else -> null
+    }
+    thisLogger().info("Bazel sync build finished with result ${event.result.javaClass.simpleName} -> $outcome")
+    synchronized(lock) { lastOutcome = outcome }
+  }
+
+  /**
+   * Matching on the build id works because the tracker only listens to [SyncViewManager]
+   * (not the Build view), and the Bazel plugin is the only producer using this task id there.
+   */
+  private fun isBazelSyncBuild(buildId: Any): Boolean =
+    when (buildId) {
+      // 2025.2.x passes the sync task id as a plain String.
+      is String -> buildId == BAZEL_SYNC_TASK_ID
+      // Newer versions pass a TaskId; its `id` property is the same constant. The getter is
+      // binary-compatible across the TaskId shape change upstream.
+      is TaskId -> buildId.id == BAZEL_SYNC_TASK_ID
+      else -> false
+    }
+
+  override fun dispose() = Unit
+
+  companion object {
+    private const val BAZEL_SYNC_TASK_ID = "project-sync"
+  }
+}
+
+/**
+ * Instantiates [BazelSyncOutcomeTracker] when a project opens so its Sync view listener is
+ * registered before the Bazel plugin starts its first sync.
+ */
+internal class BazelSyncOutcomeTrackerInitializer : ProjectActivity {
+  override suspend fun execute(project: Project) {
+    project.getService(BazelSyncOutcomeTracker::class.java)
+  }
+}

--- a/src/main/kotlin/xyz/block/idea/telemetry/services/Analytics.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/services/Analytics.kt
@@ -28,11 +28,16 @@ import java.util.Properties
 
 internal class Analytics(private val project: Project) {
 
+  // Configuration is read from gradle.properties at the project root. A repo that doesn't use
+  // Gradle (e.g. Bazel) can instead put the same properties in a file named
+  // "ide-metrics-plugin.config-file" at the project root - the same file gradle.properties can
+  // delegate to via the property of that name.
   // This is calculated once and on demand.
   // Changes to the config file will require an IJ restart.
-  private val gradleProperties: Properties by lazy {
+  private val baseProperties: Properties by lazy {
     val properties = Properties()
-    project.getFile(CONFIG_FILE_PATH)?.let { file ->
+    val file = project.getFile(GRADLE_CONFIG_FILE_PATH) ?: project.getFile(DELEGATE_FILE_PATH)
+    if (file != null) {
       InputStreamReader(file.inputStream).use {
         properties.load(it)
       }
@@ -41,7 +46,7 @@ internal class Analytics(private val project: Project) {
   }
 
   private val configProperties: Properties by lazy {
-    val b = gradleProperties.getProperty(DELEGATE_FILE_PATH)
+    val b = baseProperties.getProperty(DELEGATE_FILE_PATH)
     if (b != null) {
       val properties = Properties()
       project.getFile(b)?.let { file ->
@@ -54,7 +59,7 @@ internal class Analytics(private val project: Project) {
       properties
     } else {
       // Otherwise, use the original
-      gradleProperties
+      baseProperties
     }
   }
 
@@ -65,7 +70,10 @@ internal class Analytics(private val project: Project) {
   private val telemetrySubmitter: TelemetrySubmitter? by lazy {
     // Can't do anything if there's no endpoint in the repo's properties file
     if (endpoint.isBlank()) {
-      thisLogger().warn("No endpoint found in $CONFIG_FILE_PATH. Set one with '$ENDPOINT_PROPERTY_NAME=...'")
+      thisLogger().warn(
+        "No endpoint found. Set '$ENDPOINT_PROPERTY_NAME=...' in $GRADLE_CONFIG_FILE_PATH or " +
+          "$DELEGATE_FILE_PATH at the project root"
+      )
       return@lazy null
     }
 
@@ -113,6 +121,7 @@ internal class Analytics(private val project: Project) {
     ApplicationManager.getApplication().executeOnPooledThread {
       val syncEvent = SyncEvent(
         syncType = syncResult.resultName,
+        buildTool = syncResult.buildTool,
         syncTime = syncResult.totalDuration,
         configureIncludedBuildsDuration = if (syncResult is SyncSucceeded) syncResult.configureIncludedBuildsDuration else -1,
         configureRootProjectDuration = if (syncResult is SyncSucceeded) syncResult.configureRootProjectDuration else -1,
@@ -123,7 +132,11 @@ internal class Analytics(private val project: Project) {
         jvmFreeMemory = Runtime.getRuntime().freeMemory().toString(),
         availableProcessors = Runtime.getRuntime().availableProcessors().toLong(),
         cpuName = readCpuName(),
-        numberOfModules = if (syncResult is SyncSucceeded) syncResult.projectCount.toLong() else -1,
+        numberOfModules = when (syncResult) {
+          is SyncSucceeded -> syncResult.projectCount.toLong()
+          is SyncResult.BazelSync -> syncResult.moduleCount.toLong()
+          else -> -1
+        },
         activeWorkspace = null,
         errorMessage = if (syncResult is SyncFailed) syncResult.exception.message else null,
         studioVersion = androidStudioVersion,
@@ -149,7 +162,7 @@ internal class Analytics(private val project: Project) {
   }
 
   companion object {
-    private const val CONFIG_FILE_PATH: String = "gradle.properties"
+    private const val GRADLE_CONFIG_FILE_PATH: String = "gradle.properties"
     private const val DELEGATE_FILE_PATH: String = "ide-metrics-plugin.config-file"
     private const val ENDPOINT_PROPERTY_NAME: String = "ide-metrics-plugin.event-stream-endpoint"
 

--- a/src/main/kotlin/xyz/block/idea/telemetry/services/SyncState.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/services/SyncState.kt
@@ -56,6 +56,8 @@ internal class SyncState(private val project: Project) {
       }
       is SyncResult.SyncCancelled -> thisLogger().info("sync cancelled at ${result.phase}, Total Duration: ${result.totalDuration}ms")
       is SyncResult.SyncFailed -> thisLogger().info("sync failed at ${result.phase}, Total Duration: ${result.totalDuration}ms - ${result.exception.message}")
+      // Bazel syncs are reported directly to Analytics by the Bazel listeners and never flow through SyncState.
+      is SyncResult.BazelSync -> thisLogger().error("Unexpected Bazel sync result in SyncState: $result")
     }
     project.analyticsService.recordSyncEvent(result)
     reset()

--- a/src/main/kotlin/xyz/block/idea/telemetry/submitters/googleforms/GoogleFormsUrlParser.kt
+++ b/src/main/kotlin/xyz/block/idea/telemetry/submitters/googleforms/GoogleFormsUrlParser.kt
@@ -17,7 +17,7 @@ internal object GoogleFormsUrlParser {
 
   private val PLACEHOLDER_MAPPING: Map<String, (SyncEvent) -> String?> = mapOf(
     "SYNC_TYPE" to SyncEvent::syncType,
-    "SYNC_TIME" to SyncEvent::syncTime.toStringMapping(),
+    "BUILD_TOOL" to SyncEvent::buildTool,
     "SYNC_TIME" to SyncEvent::syncTime.toStringMapping(),
     "CONFIGURE_INCLUDED_BUILDS_DURATION" to SyncEvent::configureIncludedBuildsDuration.toStringMapping(),
     "CONFIGURE_ROOT_PROJECT_DURATION" to SyncEvent::configureRootProjectDuration.toStringMapping(),

--- a/src/main/resources/META-INF/bazel-metrics.xml
+++ b/src/main/resources/META-INF/bazel-metrics.xml
@@ -1,0 +1,11 @@
+<!-- Loaded only when the JetBrains Bazel plugin (org.jetbrains.bazel) is installed and enabled. -->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <postStartupActivity implementation="xyz.block.idea.telemetry.listeners.sync.BazelSyncOutcomeTrackerInitializer"/>
+    </extensions>
+
+    <projectListeners>
+        <listener class="xyz.block.idea.telemetry.listeners.sync.BazelSyncListener"
+                  topic="org.jetbrains.bazel.sync.status.SyncStatusListener"/>
+    </projectListeners>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,7 @@
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.gradle</depends>
     <depends>org.jetbrains.plugins.gradle</depends>
+    <depends optional="true" config-file="bazel-metrics.xml">org.jetbrains.bazel</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <externalSystemTaskNotificationListener implementation="xyz.block.idea.telemetry.listeners.sync.GradleResolveProjectTaskListener" />


### PR DESCRIPTION
Records sync duration, outcome (succeeded, failed, cancelled) and module count for Bazel syncs via the JetBrains Bazel plugin, tagged with build_tool to distinguish from Gradle. Bazel sync builds are detected by the plugin's constant task id. Repos without gradle.properties can put the endpoint config in an ide-metrics-plugin.config-file at the project root.